### PR TITLE
Remove Pipenv from getting-started guide

### DIFF
--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -252,7 +252,7 @@ Now run (inside the container):
 [source,shell]
 ----
 ssh-keyscan gitlab.com > /app/.ssh/known_hosts
-pipenv run commodore compile $CLUSTER_ID --push
+commodore compile $CLUSTER_ID --push
 ----
 
 The output will look like this:


### PR DESCRIPTION
Since we moved to Poetry.

~Only merge, once https://github.com/projectsyn/commodore/pull/102 is merged~ ✔️ 
