### PR TITLE
docs(getting started): gitlab username is required

### DIFF
--- a/docs/modules/ROOT/pages/tutorials/getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/getting-started.adoc
@@ -196,7 +196,7 @@ EOF
 
 In this section you will create your first Lieutenant configuration objects using the API to test the deployment and configuration.
 
-. Prepare access to API, replace `MYUSER` with your GitLab user id
+. Prepare access to API, replace `MYUSER` with your GitLab username
 +
 [source,shell]
 ----


### PR DESCRIPTION
got me confused for a second: a gitlab user id is something different from the username - the userid is in profile settings and can't be used to later access the created repository.


- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
