### PR TITLE
Explain rules on defining Kapitan dependencies

### DIFF
--- a/docs/modules/ROOT/pages/about/introduction.adoc
+++ b/docs/modules/ROOT/pages/about/introduction.adoc
@@ -24,7 +24,7 @@ What's next?
 * Check out the xref:about/architecture.adoc[architecture]
 * Get started with the step-by-step xref:tutorials/getting-started.adoc[Getting Started] guide
 
-== 2020-10-29 Cloud Native Bern Meetup
+== 2020–10–29 Cloud Native Bern Meetup
 
 Introduction to Project Syn at the https://www.meetup.com/cloudnativebern/events/272975884/[Cloud Native Bern Meetup]:
 

--- a/docs/modules/ROOT/pages/references/style-guide.adoc
+++ b/docs/modules/ROOT/pages/references/style-guide.adoc
@@ -419,9 +419,9 @@ local Animal(name, age) = { … }
 
 === Defining dependencies
 
-* Download external dependencies to a path within the components directory.
-* Add that dirctory to the components `.gitignore` file.
-* Ensure the outpt path changes when the upstream change.
+* Download external dependencies to a path within the component's directory.
+* Add that directory to the component's `.gitignore` file.
+* Ensure the output path changes when the upstream changes.
 +
 [CAUTION]
 ====

--- a/docs/modules/ROOT/pages/references/style-guide.adoc
+++ b/docs/modules/ROOT/pages/references/style-guide.adoc
@@ -414,3 +414,29 @@ local Animal(name, age) = { … }
 
 * Put a  https://www.doxygen.nl/manual/docblocks.html[Docblock] at the top of each Jsonnet file or library to indicate its purpose.
 * Exceptions can be made for `app.jsonnet` and `main.jsonnet`.
+
+== Commodore component style
+
+=== Defining dependencies
+
+* Download external dependencies to a path within the components directory.
+* Add that dirctory to the components `.gitignore` file.
+* Ensure the outpt path changes when the upstream change.
++
+[CAUTION]
+====
+Commodore doesn't delete those files between catalog compiles.
+If the file is already present, it won't be downloaded again.
+====
+
+[source,jsonnet]
+----
+parameters:
+  kapitan:
+    dependencies:
+      # CRDs
+      - type: https
+        source: https://raw.githubusercontent.com/argoproj/argo-cd/${argocd:git_tag}/manifests/crds/application-crd.yaml
+        output_path: dependencies/argocd/manifests/${argocd:git_tag}/crds/application-crd.yaml
+[…]
+----

--- a/slides/syntroduction/slides.adoc
+++ b/slides/syntroduction/slides.adoc
@@ -1,4 +1,4 @@
-:author: 
+:author:
 :doctitle: Introduction
 :email: ahoy@syn.tools
 :producer: VSHN AG


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

With projectsyn/commodore/pull/253, dependencies are no longer deleted when compiling a cluster. This also applies to dependencies downloaded by Kapitan. In order to prevent surprises, certain rules must be followed when writing components. This PR adds those rules to the style guide.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
