### PR TITLE
Fully version-pin Project Syn getting started guide 

### DIFF
--- a/docs/modules/ROOT/pages/tutorials/getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/getting-started.adoc
@@ -217,7 +217,10 @@ export GITLAB_USERNAME="MYUSER"
 +
 [source,shell,subs="attributes"]
 ----
-TENANT_ID=$(curl -s -H "$LIEUTENANT_AUTH" -H "Content-Type: application/json" -X POST --data "{\"displayName\":\"My first Tenant\",\"gitRepo\":{\"url\":\"ssh://git@${GITLAB_ENDPOINT}/${GITLAB_USERNAME}/mytenant\"}}" "http://${LIEUTENANT_URL}/tenants" | jq -r ".id")
+TENANT_ID=$(curl -s -H "$LIEUTENANT_AUTH" -H "Content-Type: application/json" -X POST \
+  --data "{\"displayName\":\"My first Tenant\",
+           \"gitRepo\":{\"url\":\"ssh://git@${GITLAB_ENDPOINT}/${GITLAB_USERNAME}/mytenant\"}}" \
+  "http://${LIEUTENANT_URL}/tenants" | jq -r ".id")
 echo $TENANT_ID
 echo https://${GITLAB_ENDPOINT}/${GITLAB_USERNAME}/mytenant
 ----
@@ -228,7 +231,15 @@ TIP: If everything went well, the Lieutenant Operator created a new git reposito
 +
 [source,shell]
 ----
-kubectl -n lieutenant patch tenant $TENANT_ID --type="merge" -p "{\"spec\":{\"clusterTemplate\":{\"gitRepoTemplate\":{\"apiSecretRef\":{\"name\":\"gitlab-com\"},\"path\":\"${GITLAB_USERNAME}\",\"repoName\":\"{{ .Name }}\"},\"tenantRef\":{}}}}"
+kubectl -n lieutenant patch tenant $TENANT_ID --type="merge" -p \
+"{\"spec\":{\"clusterTemplate\": {
+    \"gitRepoTemplate\": {
+      \"apiSecretRef\":{\"name\":\"gitlab-com\"},
+      \"path\":\"${GITLAB_USERNAME}\",
+      \"repoName\":\"{{ .Name }}\"
+    },
+    \"tenantRef\":{}
+}}}"
 ----
 +
 [TIP]
@@ -249,7 +260,19 @@ kubectl -n lieutenant get gitrepo
 +
 [source,shell]
 ----
-CLUSTER_ID=$(curl -s -H "$LIEUTENANT_AUTH" -H "Content-Type: application/json" -X POST --data "{ \"tenant\": \"${TENANT_ID}\", \"displayName\": \"My first Project Syn cluster\", \"facts\": { \"cloud\": \"local\", \"distribution\": \"k3s\", \"region\": \"local\" }, \"gitRepo\": { \"url\": \"ssh://git@${GITLAB_ENDPOINT}/${GITLAB_USERNAME}/cluster-gitops1.git\" } }" "http://${LIEUTENANT_URL}/clusters" | jq -r ".id")
+CLUSTER_ID=$(curl -s -H "$LIEUTENANT_AUTH" -H "Content-Type: application/json" -X POST \
+  --data "{
+            \"tenant\": \"${TENANT_ID}\",
+            \"displayName\": \"My first Project Syn cluster\",
+            \"facts\": {
+              \"cloud\": \"local\",
+              \"distribution\": \"k3s\",
+              \"region\": \"local\"
+            },
+            \"gitRepo\": {
+              \"url\": \"ssh://git@${GITLAB_ENDPOINT}/${GITLAB_USERNAME}/cluster-gitops1.git\"
+          }}" \
+  "http://${LIEUTENANT_URL}/clusters" | jq -r ".id")
 echo $CLUSTER_ID
 echo https://${GITLAB_ENDPOINT}/${GITLAB_USERNAME}/cluster-gitops1
 ----

--- a/docs/modules/ROOT/pages/tutorials/getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/getting-started.adoc
@@ -219,13 +219,16 @@ export GITLAB_USERNAME="MYUSER"
 ----
 TENANT_ID=$(curl -s -H "$LIEUTENANT_AUTH" -H "Content-Type: application/json" -X POST \
   --data "{\"displayName\":\"My first Tenant\",
-           \"gitRepo\":{\"url\":\"ssh://git@${GITLAB_ENDPOINT}/${GITLAB_USERNAME}/mytenant\"}}" \
+           \"gitRepo\":{\"url\":\"ssh://git@${GITLAB_ENDPOINT}/${GITLAB_USERNAME}/mytenant\"},
+           \"globalGitRepoRevision\":\"{commodore_version}\"}" \
   "http://${LIEUTENANT_URL}/tenants" | jq -r ".id")
 echo $TENANT_ID
 echo https://${GITLAB_ENDPOINT}/${GITLAB_USERNAME}/mytenant
 ----
 +
 TIP: If everything went well, the Lieutenant Operator created a new git repository under https://${GITLAB_ENDPOINT}/${GITLAB_USERNAME}/mytenant, which will be used to store the configuration used by Commodore to create a catalog for a cluster.
++
+NOTE: We use Lieutenant's `globalGitRepoRevision` to ensure that Commodore checks out a version of the global Git repo which is compatible with the Commodore version used in this tutorial.
 
 . Patch the Tenant object directly in Kubernetes to add a Cluster template and set the `globalGitRepoURL`.
 +

--- a/docs/modules/ROOT/pages/tutorials/getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/getting-started.adoc
@@ -1,4 +1,7 @@
 = Getting Started with Project Syn
+:commodore_version: v0.4.0
+:lieutenant_operator_version: v0.4.2
+:lieutenant_api_version: v0.4.0
 
 This guide helps to get started with the various Project Syn tools.
 
@@ -55,13 +58,13 @@ kubectl create namespace lieutenant
 
 Install *Lieutenant Operator* with the following commands:
 
-[source,shell]
+[source,shell,subs="attributes"]
 ----
 # CRDs (global scope)
-kubectl apply -k "github.com/projectsyn/lieutenant-operator/deploy/crds?ref=v0.4.2"
+kubectl apply -k "github.com/projectsyn/lieutenant-operator/deploy/crds?ref={lieutenant_operator_version}"
 
 # Operator deployment
-kubectl -n lieutenant apply -k "github.com/projectsyn/lieutenant-operator/deploy?ref=v0.4.2"
+kubectl -n lieutenant apply -k "github.com/projectsyn/lieutenant-operator/deploy?ref={lieutenant_operator_version}"
 
 # Operator configuration
 kubectl -n lieutenant set env deployment/lieutenant-operator -c lieutenant-operator \
@@ -82,10 +85,10 @@ These environment variables will configure Lieutenant Operator to:
 
 Install *Lieutenant API* with the following commands:
 
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
 # API deployment
-kubectl -n lieutenant apply -k "github.com/projectsyn/lieutenant-api/deploy?ref=v0.4.0"
+kubectl -n lieutenant apply -k "github.com/projectsyn/lieutenant-api/deploy?ref={lieutenant_api_version}"
 
 # API configuration
 kubectl -n lieutenant set env deployment/lieutenant-api -c lieutenant-api \
@@ -212,7 +215,7 @@ export GITLAB_USERNAME="MYUSER"
 
 . Create a *Lieutenant Tenant* via the API
 +
-[source,shell]
+[source,shell,subs="attributes"]
 ----
 TENANT_ID=$(curl -s -H "$LIEUTENANT_AUTH" -H "Content-Type: application/json" -X POST --data "{\"displayName\":\"My first Tenant\",\"gitRepo\":{\"url\":\"ssh://git@${GITLAB_ENDPOINT}/${GITLAB_USERNAME}/mytenant\"}}" "http://${LIEUTENANT_URL}/tenants" | jq -r ".id")
 echo $TENANT_ID
@@ -279,11 +282,11 @@ Execute the following command which will start the properly configured Commodore
 
 Replace `MYSSHKEYPATH` with the path to your SSH key file, for example `~/.ssh/id_rsa`. This SSH key will be used to push the generated configuration catalog to the Git repository managed by Lieutenant.
 
-[source,shell]
+[source,shell,subs="attributes"]
 ----
 export COMMODORE_SSH_PRIVATE_KEY=MYSSHKEYPATH
 kubectl -n lieutenant run commodore-shell \
-  --image=docker.io/projectsyn/commodore:v0.4.0 \
+  --image=docker.io/projectsyn/commodore:{commodore_version} \
   --env=COMMODORE_API_URL="http://${LIEUTENANT_URL}/" \
   --env=COMMODORE_API_TOKEN=${LIEUTENANT_TOKEN} \
   --env=SSH_PRIVATE_KEY="$(cat ${COMMODORE_SSH_PRIVATE_KEY})" \


### PR DESCRIPTION
This PR makes the following changes to the Project Syn getting started guide (https://syn.tools/syn/tutorials/getting-started.html)

* Make the Commodore and Lieutenant versions used by the guide page attributes
* Reformat some of the longer `kubectl` and `curl` commands to improve readability
* Pin the global Git repo (https://github.com/projectsyn/getting-started-commodore-defaults) to the Commodore version used in the getting started guide.
This eliminates the need to update the getting started guide and the getting-started-commodore-defaults repo in lockstep. Conversely, updating the Commodore version in the getting started guide now requires creating a new tag on the getting-started-commodore-defaults repo.

This is in preparation for https://github.com/projectsyn/commodore/pull/284 and https://github.com/projectsyn/getting-started-commodore-defaults/pull/4
## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
