### PR TITLE
Add how-to page to compile a cluster

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -37,6 +37,7 @@ include::steward:ROOT:partial$nav-tutorials.adoc[]
 
 .How-to guides
 * xref:how-tos/release-process.adoc[Release Process]
+* xref:how-tos/compile-catalog.adoc[Compile a catalog]
 * xref:how-tos/change-parameter.adoc[Change a parameter]
 * Commodore
 +

--- a/docs/modules/ROOT/pages/how-tos/change-parameter.adoc
+++ b/docs/modules/ROOT/pages/how-tos/change-parameter.adoc
@@ -1,19 +1,9 @@
 = Change a parameter
 
 Suppose you want to overwrite an inventory parameter for a cluster or tenant.
-This page assumes that you have already set up access to Lieutenant, so that `commodore catalog compile` generally works from any directory.
 
-TIP: To run `commodore` from any directory, it should be in `$PATH` or an alias to a containerized Commodore.
+. xref:how-tos/compile-catalog.adoc[Compile the cluster first] (don't push your changes to git yet)
 
-. Get the Cluster and Tenant ID from Lieutenant and compile the catalog.
-+
-[source,bash]
-----
-export $CLUSTER_ID = <target-cluster-id>
-dir=$(mktemp -d)
-pushd "${dir}"
-commodore catalog compile $CLUSTER_ID
-----
 . Open your editor and edit the files you need to change.
 +
 [TIP]
@@ -42,5 +32,5 @@ popd
 commodore catalog compile $CLUSTER_ID --push --interactive
 # Cleanup
 popd
-rm -r "${dir}"
+rm -rf "${dir}"
 ----

--- a/docs/modules/ROOT/pages/how-tos/compile-catalog.adoc
+++ b/docs/modules/ROOT/pages/how-tos/compile-catalog.adoc
@@ -1,0 +1,76 @@
+= Compile a catalog
+
+Compile and push a cluster catalog from local machine to update dependencies.
+
+== Requirements
+
+* A https://syn.tools/commodore/running-commodore.html[working commodore command].
+* An access token to a running Lieutenant instance. Storing the token as a kubeconfig is recommended.
+* An existing Cluster in Lieutenant.
+
+== Prepare Commodore
+
+The following snippet sets up needed environment variables in your current working directory.
+
+TIP: You can skip this step if you have already defined them already with another method.
+
+[source,bash]
+----
+# Assuming "syn-synfra" is the user in your kubeconfig
+LIEUTENANT_TOKEN=$(kubectl config view -o jsonpath='{.users[?(@.name == "syn-synfra")].user.token}'  --raw)
+LIEUTENANT_URL="the-public-lieutenant-API-URL"
+
+cat << EOF > .env
+LIEUTENANT_AUTH="Authorization:Bearer ${LIEUTENANT_TOKEN}"
+LIEUTENANT_URL="${LIEUTENANT_URL}"
+COMMODORE_API_TOKEN="${LIEUTENANT_TOKEN}"
+COMMODORE_API_URL="${LIEUTENANT_URL}"
+EOF
+
+# Double check the environment variables
+less .env
+
+# Export the variables
+set -a; source .env; set +a
+----
+
+== Compilation
+
+.Choose cluster
+
+. Get the Cluster ID from Lieutenant.
++
+[source,bash]
+----
+commodore catalog list -v
+----
+. Set the cluster ID and prepare directory.
++
+[source,bash]
+----
+export CLUSTER_ID = <target-cluster-name-from-above>
+dir=$(mktemp -d)
+pushd "${dir}"
+----
+
+.Choose operation
+. Compile the catalog and display a diff.
++
+[source,bash]
+----
+commodore catalog compile $CLUSTER_ID
+----
+
+. Compile the catalog and push.
++
+[source,bash]
+----
+commodore catalog compile $CLUSTER_ID --push --interactive
+----
+
+.Cleanup
+[source,bash]
+----
+popd
+rm -rf "${dir}"
+----


### PR DESCRIPTION
* Adds a dedicated how-to page to compile clusters including setting environment variables.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
