### PR TITLE
align makefile with other projects

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,15 +7,10 @@ on:
 jobs:
   linting:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        command:
-          - lint_yaml
-          - docs-vale
     steps:
       - uses: actions/checkout@v2
-      - name: Run ${{ matrix.command }}
-        run: make ${{ matrix.command }}
+      - name: Run YAML lint
+        run: make lint_yaml
 
   editorconfig:
     runs-on: ubuntu-latest
@@ -23,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: snow-actions/eclint@v1.0.1
         with:
-          args: 'check'
+          args: "check"
 
   docs:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,38 +1,73 @@
-MAKEFLAGS += --warn-undefined-variables
-SHELL := bash
-.SHELLFLAGS := -eu -o pipefail -c
-.DEFAULT_GOAL := all
-.DELETE_ON_ERROR:
-.SUFFIXES:
+pages   := $(shell find . -type f -name '*.adoc')
+out_dir := ./_public
 
-ANTORA_PREVIEW_CMD ?= $(DOCKER_CMD) run --rm --publish 35729:35729 --publish 2020:2020 --volume "${PWD}":/preview/antora vshn/antora-preview:2.3.7 --style=syn --antora=docs
+docker_cmd  ?= docker
+docker_opts ?= --rm --tty --user "$$(id -u)"
 
-DOCKER_CMD  ?= docker
-DOCKER_ARGS ?= run --rm --user "$$(id -u)" --volume "$${PWD}:/src" --workdir /src
+antora_cmd  ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}":/antora vshn/antora:2.3.3
+antora_opts ?= --cache-dir=.cache/antora
 
-YAML_FILES      ?= $(shell find . -type f -name '*.yaml' -or -name '*.yml')
-YAMLLINT_ARGS   ?= --no-warnings
-YAMLLINT_CONFIG ?= .yamllint.yml
-YAMLLINT_IMAGE  ?= docker.io/cytopia/yamllint:latest
-YAMLLINT_DOCKER ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(YAMLLINT_IMAGE)
+asciidoctor_cmd  ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}":/documents/ asciidoctor/docker-asciidoctor asciidoctor
+asciidoctor_opts ?= --destination-dir=$(out_dir)
+asciidoctor_kindle_opts ?= --attribute ebook-format=kf8
 
-VALE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) --volume "$${PWD}"/docs/modules:/pages vshn/vale:2.1.1
-VALE_ARGS ?= --minAlertLevel=error --config=/pages/ROOT/pages/.vale.ini /pages
+vale_cmd ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}"/docs/modules/ROOT/pages:/pages vshn/vale:2.6.1 --minAlertLevel=error /pages
+hunspell_cmd ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}":/spell vshn/hunspell:1.7.0 -d en,vshn -l -H _public/**/*.html
+htmltest_cmd ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}"/_public:/test wjdp/htmltest:v0.12.0
+preview_cmd ?= $(docker_cmd) run --rm --publish 35729:35729 --publish 2020:2020 --volume "${PWD}":/preview/antora vshn/antora-preview:2.3.6 --antora=docs --style=syn
+
+yaml_files      ?= $(shell find . -type f -name '*.yaml' -or -name '*.yml')
+yamllint_args   ?= --no-warnings
+yamllint_config ?= .yamllint.yml
+yamllint_image  ?= docker.io/cytopia/yamllint:latest
+yamllint_docker ?= $(docker_cmd) run $(docker_opts) --volume "$${PWD}:/src" --workdir /src $(yamllint_image)
+
 
 .PHONY: all
-all: lint docs open
+all: html
 
-.PHONY: lint
-lint: lint_yaml docs-vale
+# This will clean the Antora Artifacts, not the npm artifacts
+.PHONY: clean
+clean:
+	rm -rf $(out_dir) '?' .cache
+
+.PHONY: check
+check:
+	$(vale_cmd) lint_yaml
+
+.PHONY: vale
+vale:
+	$(vale_cmd)
 
 .PHONY: lint_yaml
-lint_yaml: $(YAML_FILES)
-	$(YAMLLINT_DOCKER) -f parsable -c $(YAMLLINT_CONFIG) $(YAMLLINT_ARGS) -- $?
+lint_yaml: $(yaml_files)
+	$(yamllint_docker) -f parsable -c $(yamllint_config) $(yamllint_args) -- $?
 
-.PHONY: docs-serve
-docs-serve:
-	$(ANTORA_PREVIEW_CMD)
+# This target lists the images not used in the final website,
+# and which could be removed. This command requires `ag` installed:
+# https://github.com/ggreer/the_silver_searcher
+.PHONY: unused_images
+unused_images: html
+	@for file in docs/modules/ROOT/assets/images/* ; do \
+		if ! ag -U $${file##*/} _public > /dev/null; then \
+			echo $$file; \
+		fi; \
+	done;
 
-.PHONY: docs-vale
-docs-vale:
-	$(VALE_CMD) $(VALE_ARGS)
+.PHONY: syntax
+syntax: html
+	$(hunspell_cmd)
+
+.PHONY: htmltest
+htmltest: html pdf epub kindle manpage
+	$(htmltest_cmd)
+
+.PHONY: preview
+preview:
+	$(preview_cmd)
+
+.PHONY: html
+html:    $(out_dir)/index.html
+
+$(out_dir)/index.html: playbook.yml $(pages)
+	$(antora_cmd) $(antora_opts) $<

--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 # Project Syn Documentation
 
-This is the umbrella documentation for project syn.
-It is written using [Asciidoc][asciidoc] and [Antora][antora] and located in the [docs/](docs) folder.
+This is the umbrella documentation for Project Syn.
+It is written using [AsciiDoc][asciidoc] and [Antora][antora] and located in the [docs/](docs) folder.
 The [Divio documentation structure](https://documentation.divio.com/) is used to organize its content.
 
-Run the `make docs-serve` command in the root of the project, and then browse to http://localhost:2020 to see a preview of the documentation.
-
-After writing the documentation, please use the `make docs-vale` command and correct any warnings raised by the tool.
+Run the `make preview` command in the root of the project, and then browse to http://localhost:2020 to see a preview of the documentation.
 
 ## Contributing and license
 
-This library is licensed under [BSD-3-Clause](LICENSE).
+This project is licensed under [BSD-3-Clause](LICENSE).
 For information about how to contribute see [CONTRIBUTING](CONTRIBUTING.md).
 
 [asciidoc]: https://asciidoctor.org/


### PR DESCRIPTION
This PR aligns the Makefile with other projects we're using. It mainly makes sure that `make preview` is available to have the local preview up and running, instead of `make docs-serve`, like in any other Antora documentation project we're having.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
