### PR TITLE
Upgrade commodore to v0.8.2 in getting started tutorial

### DIFF
--- a/docs/modules/ROOT/pages/tutorials/getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/getting-started.adoc
@@ -1,5 +1,5 @@
 = Getting Started with Project Syn
-:commodore_version: v0.5.0
+:commodore_version: v0.8.2
 :lieutenant_operator_version: v0.4.2
 :lieutenant_api_version: v0.4.0
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

Currently the tutorial is stuck in [Kickstart Steward](https://syn.tools/syn/tutorials/getting-started.html#_kickstart_steward). ArgoCD won't fully sync because of some missing prometheus CRDs. This was fixed in projectsyn/getting-started-commodore-defaults/pull/5 and this PR updates the commodore tutorial defaults to include this fix.

Tested the tutorial with the new commodore version and runs from start to finish without hickups.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Test changes.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
