### PR TITLE
Fix getting started tutorial on docker-desktop where INGRESS_IP can be 127.0.0.1

### DIFF
--- a/docs/modules/ROOT/pages/tutorials/getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/getting-started.adoc
@@ -403,6 +403,7 @@ echo $STEWARD_INSTALL
 [source,shell]
 ----
 kubectl apply -f $STEWARD_INSTALL
+if [[ "$INGRESS_IP" == "127.0.0.1" ]]; then; kubectl -n syn set env deployment/steward -c steward STEWARD_API=http://lieutenant-api.lieutenant; fi
 ----
 . Check the validity of the bootstrap token
 +


### PR DESCRIPTION
This PR fixes the getting started tutorial on Docker Desktop for MacOS where the ingress IP is `127.0.0.1`.

Steward can't reach lieutenant under `lieutenant.127.0.0.1.nip.io` since `127.0.0.1` points to the local container. This PR updates the steward `STEWARD_API` environment variable to the cluster local dns entry if `${INGRESS_IP}` is `127.0.0.1`.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
