### PR TITLE
Fix "User-provided secrets" example in Commodore component best practices

### DIFF
--- a/docs/modules/ROOT/pages/explanations/commodore-components/secrets.adoc
+++ b/docs/modules/ROOT/pages/explanations/commodore-components/secrets.adoc
@@ -31,17 +31,28 @@ The implementation iterates over the fields of parameter `secrets` and merges th
 // We assume that
 // * the component's parameters are available as local variable `params`.
 // * kube-libsonnet is available as local variable `kube`.
-local secrets = {
-  kube.Secret(s) {
-    metadata+: {
-      namespace: params.namespace,
-    }
-  } + params.secrets[s]
+// * commodore.libjsonnet is available as local variable `com`.
+//
+// We use `com.makeMergeable()` to ensure that user-provided secret values
+// don't accidentally remove `metadata.name`.
+// To allow users to remove secrets configured higher-up in the hierarchy, we
+// only generate `Secret` resources for elements of `params.secrets` which are
+// non-null. Therefore the variable `secrets` will contain a mix of `Secret`
+// resources and `null` entries.
+local secrets = [
+  if params.secrets[s] != null then
+    kube.Secret(s) {
+      metadata+: {
+        namespace: params.namespace,
+      }
+    } + com.makeMergeable(params.secrets[s])
   for s in std.objectFields(params.secrets)
-};
+];
 
 {
-  secrets: secrets,
+  // We use Jsonnet's `std.filter()` to filter out null entries from the
+  // `secrets` variable to have a clean output file.
+  secrets: std.filter(function(it) it != null, secrets),
 }
 ----
 


### PR DESCRIPTION

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
