### PR TITLE
Update "Compile a catalog" how-to

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/compile-catalog.adoc
+++ b/docs/modules/ROOT/pages/how-tos/compile-catalog.adoc
@@ -13,26 +13,43 @@ See the next section for details on how to connect to Lieutenant instances with 
 
 The following snippet sets up needed environment variables in your current working directory.
 
-TIP: You can skip this step if you have already defined them already with another method.
+TIP: You can skip this section if you have already defined the required environment variables.
 
-. Setup required environment variables
+. Set Lieutenant API URL
++
+[source,bash]
+----
+COMMODORE_API_URL=https://syn.example.com <1>
+----
+<1> Replace with the URL of your Lieutenant instance
+
+. Determine whether the Lieutenant instance uses OIDC authentication:
++
+[source,bash]
+----
+curl ${COMMODORE_API_URL}
+----
++
+If the response contains field `oidc`, the Lieutenant API instance uses OIDC authentication.
+Otherwise, please check with your Project Syn administrators for details on how to authenticate against the Lieutenant API.
+
+. Setup the `.env` file for Commodore
 +
 .Lieutenant instance using OIDC token
 [%collapsible]
 ====
 [source,bash]
 ----
-LIEUTENANT_URL="the-public-lieutenant-API-URL"
-
 cat << EOF > .env
 LIEUTENANT_AUTH="Authorization:Bearer \$(commodore fetch-token)"
-LIEUTENANT_URL="${LIEUTENANT_URL}"
-COMMODORE_API_URL="${LIEUTENANT_URL}"
+LIEUTENANT_URL="${COMMODORE_API_URL}"
+COMMODORE_API_URL="${COMMODORE_API_URL}"
 EOF
 ----
 
 [NOTE]
-The command `commodore fetch-token` in variable `LIEUTENANT_AUTH` will be executed when you source the `.env` file.
+For some how-tos, you'll need to source the `.env` file.
+In those cases, the command `commodore fetch-token` in variable `LIEUTENANT_AUTH` will be executed at the time you source the `.env` file.
 You may need to re-source the file when following a longer guide as the OIDC token will usually have a lifetime of only a few minutes.
 ====
 +
@@ -41,7 +58,7 @@ You may need to re-source the file when following a longer guide as the OIDC tok
 ====
 [source,bash]
 ----
-# Assuming "syn-synfra" is the user in your kubeconfig
+# Assuming "syn-synfra" is the user for the cluster hosting the Lieutenant API in your kubeconfig
 LIEUTENANT_TOKEN=$(kubectl config view -o jsonpath='{.users[?(@.name == "syn-synfra")].user.token}'  --raw)
 LIEUTENANT_URL="the-public-lieutenant-API-URL"
 
@@ -53,17 +70,12 @@ COMMODORE_API_URL="${LIEUTENANT_URL}"
 EOF
 ----
 ====
-
-. Activate the configured environment variables
 +
-[source,bash]
-----
-# Double check the environment variables
-less .env
-
-# Export the variables
-set -a; source .env; set +a
-----
+[TIP]
+====
+Commodore will automatically load environment variables from file `.env` in the working directory.
+When you're just compiling a cluster catalog, you don't need to source the file.
+====
 
 == Compilation
 


### PR DESCRIPTION
Simplify and clarify steps needed to setup the Commodore environment variables:

* Add a step to check whether the Lieutenant API instance uses OIDC authentication.
* Remove the step to source the `.env` file, as that's not required when just compiling a cluster catalog.
* Add a tip noting that Commodore will automatically load environment variables from file `.env`.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
