### PR TITLE
Update deprecated helm_params.release_name

### DIFF
--- a/docs/modules/ROOT/pages/explanations/commodore-components/helm-charts.adoc
+++ b/docs/modules/ROOT/pages/explanations/commodore-components/helm-charts.adoc
@@ -55,7 +55,7 @@ parameters:
         output_path: my-component/01_helmchart
         helm_values: ${my_component:helm_values} <2>
         helm_params: <3>
-          release_name: syn-my-chart
+          name: syn-my-chart
           namespace: ${my_component:namespace}
 ----
 <1> The Helm chart name.


### PR DESCRIPTION
`helm_params.release_name` is now `helm_params.name`. Deprecation warning was:

> using 'release_name' to specify the output name is deprecated. Use 'name' instead


- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
